### PR TITLE
multiGet: handle 404s less noisy

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,6 +98,13 @@ func multiGet(servers []string, uri string) []serverResponse {
 			}
 			defer resp.Body.Close()
 
+			if resp.StatusCode == 404 {
+				// carbonsserver replies with Not Found if we request a
+				// metric that it doesn't have -- makes sense
+				ch <- serverResponse{server, nil}
+				return
+			}
+
 			if resp.StatusCode != 200 {
 				logger.Logln("bad response code ", server, "/", uri, ":", resp.StatusCode)
 				ch <- serverResponse{server, nil}


### PR DESCRIPTION
carbonserver returns 404s for metrics that don't exist, instead of an
empty result.  This is easier for both carbonserver as well as us
(carbonzipper) because it means no pickle has to be constructed, as well
as no pickle has to be unpacked, let alone an empty array examined.
