### PR TITLE
Rename metric name for slow requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -719,7 +719,7 @@ func main() {
 	}
 
 	// +1 to track every over the number of buckets we track
-	timeBuckets = make([]int64, Config.Buckets+1)
+	timeBuckets = make([]int64, Config.Buckets)
 
 	httputil.PublishTrackedConnections("httptrack")
 	expvar.Publish("requestBuckets", expvar.Func(renderTimeBuckets))

--- a/main.go
+++ b/main.go
@@ -718,7 +718,6 @@ func main() {
 		Limiter = newServerLimiter(Config.Backends, Config.ConcurrencyLimitPerServer)
 	}
 
-	// +1 to track every over the number of buckets we track
 	timeBuckets = make([]int64, Config.Buckets)
 
 	httputil.PublishTrackedConnections("httptrack")


### PR DESCRIPTION
It was a great surprise for us that last bucket also contain all slow requests :)
