### PR TITLE
Port travis-related changes from carbonapi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: go
 dist: trusty
 
-go:
-  - 1.x
-  - 1.7.x
-  - 1.8.x
-  - master
+sudo: required
 
-after_success:
-  - make test
+services:
+  - docker
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install mercurial pkg-config wget -y
+  - wget "https://raw.githubusercontent.com/go-graphite/helper-scripts/master/travis-docker-build.sh" && chmod +x ./travis-docker-build.sh && ./travis-docker-build.sh carbonzipper
+
+matrix:
+  include:
+    - go: 1.x
+      env: BUILD_PACKAGES=true
+    - go: 1.7.x
+    - go: 1.8.x
+    - go: master


### PR DESCRIPTION
Travis now will build rpm and deb packages automatically.