### PR TITLE
Deduplicate servers in pathCache

### DIFF
--- a/zipper/zipper.go
+++ b/zipper/zipper.go
@@ -761,9 +761,21 @@ func (z *Zipper) Find(ctx context.Context, logger *zap.Logger, query string) ([]
 
 		// update our cache of which servers have which metrics
 		allServers := make([]string, 0)
+		allServersSeen := make(map[string]struct{})
 		for k, v := range paths {
-			z.pathCache.Set(k, v)
-			allServers = append(allServers, v...)
+			servers := make([]string, 0)
+			serversSeen := make(map[string]struct{})
+			for _, s := range v {
+				if _, ok := serversSeen[s]; !ok {
+					serversSeen[s] = struct{}{}
+					servers = append(servers, s)
+				}
+				if _, ok := allServersSeen[s]; !ok {
+					allServersSeen[s] = struct{}{}
+					allServers = append(allServers, s)
+				}
+			}
+			z.pathCache.Set(k, servers)
 		}
 		z.pathCache.Set(query, allServers)
 	}


### PR DESCRIPTION
The problem:
If we have 1 backend server (Server1) and send query with Metric[1-3] in query - z.pathCacheSet() write {Metric1, Server1}; {Metric2, Server1}; {Metric3, Server1} and at z.pathCache.Set(query, allServers) it write {Metric[1-3], [Server1, Server1, Server1]}. Because of that on backend Server1 we have 3 render Metric[1-3] request.
Solution:
This code deduplicate all combination of backend servers.