### PR TITLE
Fix for panic when trying to merge stats with carbonsearch enabled

### DIFF
--- a/zipper/zipper.go
+++ b/zipper/zipper.go
@@ -347,7 +347,11 @@ func (z Zipper) FetchProtoV3(ctx context.Context, request *protov3.MultiFetchReq
 					Metrics: []string{metric.Name},
 				}
 				res, stat, err := z.searchBackends.Find(ctx, r)
-				statsSearch.Merge(stat)
+				if statsSearch == nil {
+					statsSearch = stat
+				} else {
+					statsSearch.Merge(stat)
+				}
 				if err != nil {
 					e.Merge(err)
 					continue

--- a/zipper/zipper.go
+++ b/zipper/zipper.go
@@ -384,7 +384,11 @@ func (z Zipper) FetchProtoV3(ctx context.Context, request *protov3.MultiFetchReq
 
 	res, stats, err := z.storeBackends.Fetch(ctx, request)
 	if statsSearch != nil {
-		stats.Merge(statsSearch)
+		if stats == nil {
+			stats = statsSearch
+		} else {
+			stats.Merge(statsSearch)
+		}
 	}
 
 	e.Merge(err)


### PR DESCRIPTION
The panic was happening while trying to merge stats of zipper find requests.